### PR TITLE
Fix crash when NIneq is dynamic

### DIFF
--- a/eigen-qp.hpp
+++ b/eigen-qp.hpp
@@ -123,6 +123,10 @@ public:
             if (NVars == -1) {
                 x.resize(n_vars);
             }
+            if (NIneq == -1) {
+                s.resize(n_const);
+                z.resize(n_const);
+            }
         }
 
     ~QPIneqSolver() {}


### PR DESCRIPTION
When NIneq is dynamic(-1), s and z's dimention is zero.
It leads crash.